### PR TITLE
Refactor Temporal Explorer

### DIFF
--- a/dist/temporal.explorer.d.ts
+++ b/dist/temporal.explorer.d.ts
@@ -1,7 +1,7 @@
 import { OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { DiscoveryService, MetadataScanner, ModuleRef } from '@nestjs/core';
 import { TemporalMetadataAccessor } from './temporal-metadata.accessors';
-import { WorkerOptions, NativeConnectionOptions } from '@temporalio/worker';
+import { Worker, WorkerOptions, NativeConnectionOptions } from '@temporalio/worker';
 import { UntypedActivities } from '@temporalio/activity';
 export declare class TemporalExplorer implements OnModuleInit, OnModuleDestroy {
     private readonly moduleRef;
@@ -9,13 +9,17 @@ export declare class TemporalExplorer implements OnModuleInit, OnModuleDestroy {
     private readonly metadataAccessor;
     private readonly metadataScanner;
     private readonly injector;
-    private worker;
     private connection;
-    private workerPromise;
+    private workerPromises;
+    private workers;
+    private activities;
     constructor(moduleRef: ModuleRef, discoveryService: DiscoveryService, metadataAccessor: TemporalMetadataAccessor, metadataScanner: MetadataScanner);
     onModuleInit(): Promise<void>;
     onModuleDestroy(): Promise<void>;
-    runWorker(): Promise<void>;
+    runWorker(workerOptions?: Partial<WorkerOptions>): Promise<{
+        worker: Worker;
+        workerPromise: Promise<void>;
+    }>;
     explore(): Promise<void>;
     getWorkerConfigOptions(name?: string): WorkerOptions;
     getNativeConnectionConfigOptions(name?: string): NativeConnectionOptions;

--- a/dist/temporal.explorer.js
+++ b/dist/temporal.explorer.js
@@ -42,13 +42,13 @@ let TemporalExplorer = class TemporalExplorer {
     }
     onModuleDestroy() {
         return __awaiter(this, void 0, void 0, function* () {
-            this.workers.map(worker => worker.shutdown());
-            yield Promise.all(this.workerPromises);
             try {
+                this.workers.map(worker => worker.shutdown());
+                yield Promise.all(this.workerPromises);
                 yield this.connection.close();
             }
             catch (e) {
-                console.error('Connection already closed');
+                console.error('Workers or connection already closed');
             }
         });
     }

--- a/dist/temporal.explorer.js
+++ b/dist/temporal.explorer.js
@@ -44,7 +44,12 @@ let TemporalExplorer = class TemporalExplorer {
         return __awaiter(this, void 0, void 0, function* () {
             this.workers.map(worker => worker.shutdown());
             yield Promise.all(this.workerPromises);
-            yield this.connection.close();
+            try {
+                yield this.connection.close();
+            }
+            catch (e) {
+                console.error('Connection already closed');
+            }
         });
     }
     runWorker(workerOptions) {

--- a/lib/temporal.explorer.ts
+++ b/lib/temporal.explorer.ts
@@ -38,7 +38,11 @@ export class TemporalExplorer
   async onModuleDestroy() {
     this.workers.map( worker => worker.shutdown());
     await Promise.all(this.workerPromises);
-    await this.connection.close();
+    try {
+      await this.connection.close();
+    } catch (e) {
+      console.error('Connection already closed');
+    }
   }
 
   async runWorker(workerOptions?: Partial<WorkerOptions>): Promise<{worker: Worker, workerPromise: Promise<void>}> {

--- a/lib/temporal.explorer.ts
+++ b/lib/temporal.explorer.ts
@@ -36,12 +36,12 @@ export class TemporalExplorer
   }
 
   async onModuleDestroy() {
-    this.workers.map( worker => worker.shutdown());
-    await Promise.all(this.workerPromises);
     try {
+      this.workers.map( worker => worker.shutdown());
+      await Promise.all(this.workerPromises);
       await this.connection.close();
     } catch (e) {
-      console.error('Connection already closed');
+      console.error('Workers or connection already closed');
     }
   }
 


### PR DESCRIPTION
Allow Temporal Explorer to spin up multiple workers. Only runs workers upon runWorker call, not upon initialization/this.explore().